### PR TITLE
Bump mathjs

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -65,7 +65,7 @@
     "lob": "4.0.0",
     "mailcomposer": "2.1.0",
     "mailgun-js": "0.7.6",
-    "mathjs": "^2.6.0",
+    "mathjs": "^3.18.0",
     "mime-types": "^2.1.15",
     "mocha": "~3.1.2",
     "mocha-junit-reporter": "^1.12.1",


### PR DESCRIPTION
Previous version allowed remote code execution
https://nvd.nist.gov/vuln/detail/CVE-2017-1001002